### PR TITLE
Wifi: Syncronization on reading and writing ringbuffer

### DIFF
--- a/wifi/1.2/default/wifi_chip.cpp
+++ b/wifi/1.2/default/wifi_chip.cpp
@@ -1177,6 +1177,8 @@ WifiStatus WifiChip::registerDebugRingBufferCallback() {
                 LOG(ERROR) << "Error converting ring buffer status";
                 return;
             }
+            {
+            std::unique_lock<std::mutex> lk(shared_ptr_this->lock_t);
             const auto& target = shared_ptr_this->ringbuffer_map_.find(name);
             if (target != shared_ptr_this->ringbuffer_map_.end()) {
                 Ringbuffer& cur_buffer = target->second;
@@ -1184,6 +1186,7 @@ WifiStatus WifiChip::registerDebugRingBufferCallback() {
             } else {
                 LOG(ERROR) << "Ringname " << name << " not found";
                 return;
+            }
             }
         };
     legacy_hal::wifi_error legacy_status =
@@ -1452,6 +1455,8 @@ bool WifiChip::writeRingbufferFilesInternal() {
         return false;
     }
     // write ringbuffers to file
+    {
+    std::unique_lock<std::mutex> lk(lock_t);
     for (const auto& item : ringbuffer_map_) {
         const Ringbuffer& cur_buffer = item.second;
         if (cur_buffer.getData().empty()) {
@@ -1471,6 +1476,7 @@ bool WifiChip::writeRingbufferFilesInternal() {
                 LOG(ERROR) << "Error writing to file " << strerror(errno);
             }
         }
+    }
     }
     return true;
 }

--- a/wifi/1.2/default/wifi_chip.h
+++ b/wifi/1.2/default/wifi_chip.h
@@ -19,6 +19,7 @@
 
 #include <list>
 #include <map>
+#include <mutex>
 
 #include <android-base/macros.h>
 #include <android/hardware/wifi/1.2/IWifiChip.h>
@@ -231,6 +232,7 @@ class WifiChip : public V1_2::IWifiChip {
     bool is_valid_;
     // Members pertaining to chip configuration.
     uint32_t current_mode_id_;
+    std::mutex lock_t;
     std::vector<IWifiChip::ChipMode> modes_;
     // The legacy ring buffer callback API has only a global callback
     // registration mechanism. Use this to check if we have already


### PR DESCRIPTION
Currently on receiving driver Event, wifi-hal triggered
framework callback to write WLAN driver/firmware logs to
respective ringbuffer and while reading this ringbuffer
from Wifi framework their is no syncronization , so with
this way ring buffer goes to inappropriate state.
This commit introduces to add syncronization between
read and write of ring buffer.

Change-Id: I44c3bdcd43e2bbc3b431fd788ff4887b64145776
CRs-Fixed: 2424315